### PR TITLE
fix(email): colour of 'failure' column

### DIFF
--- a/report_templates/report.html
+++ b/report_templates/report.html
@@ -160,7 +160,7 @@
                         <td>{{ summary.testsuite_summary.time }}</td>
                         <td>{{ summary.testsuite_summary.tests }}</td>
                         <td>{{ summary.testsuite_summary.tests - summary.testsuite_summary.skipped - summary.testsuite_summary.failures - summary.testsuite_summary.errors }}</td>
-                        {% if summary.failures == 0 %}
+                        {% if summary.testsuite_summary.failures == 0 %}
                             <td>{{ summary.testsuite_summary.failures }}</td>
                         {% else %}
                             <td class='result_table_error'>{{ summary.testsuite_summary.failures }}</td>


### PR DESCRIPTION
If no failures for a version, column 'failure' in the email is marked with red anyway. Wrong object is taken for check condition

Test:
https://argus.scylladb.com/test/bd78a051-9bdd-4f70-b554-b881cd3cf1b7/runs?additionalRuns[]=bcf411f3-4fcb-4e28-95c5-7e0889c8e8bd

![Screenshot from 2024-05-01 14-27-28](https://github.com/scylladb/scylla-rust-driver-matrix/assets/34435448/f1e2ab10-af44-40c8-a820-33893140d702)
