### PR TITLE
improvement(cargo): not stop on failed test

### DIFF
--- a/run.py
+++ b/run.py
@@ -125,7 +125,7 @@ class Run:
             run_command_in_shell(driver_repo_path=self._rust_driver_git,
                                  cmd=f"cd {self._rust_driver_git}; cargo build --verbose --examples")
             test_command = f"{scylla_uri_per_node(nodes_ips=cluster_nodes_ip)} " \
-                           "cargo test --verbose -- -Z unstable-options --format json --report-time | " \
+                           "cargo test --verbose --no-fail-fast -- -Z unstable-options --format json --report-time | " \
                            f"tee rust_results_{self._full_driver_version}.jsocat rust_results_{self._full_driver_version}.json | " \
                            f"/usr/local/cargo/bin/cargo2junit > rust_results_{self._full_driver_version}.xml"
             logging.info("Test command: %s", test_command)


### PR DESCRIPTION
Add `--no-fail-fast` parameter to cargo command.
It allows to complete all testsuit testscases even if one of the tests failed.

According to https://github.com/scylladb/scylla-rust-driver/issues/1005

### Testing

- [x] [rust-driver-matrix](https://argus.scylladb.com/test/bd78a051-9bdd-4f70-b554-b881cd3cf1b7/runs?additionalRuns[]=24fd5718-b301-451d-bbb8-3afc0cb03ab7)