### PR TITLE
Report ignored_on_failure tests in the email

### DIFF
--- a/processjunit.py
+++ b/processjunit.py
@@ -43,7 +43,7 @@ class ProcessJUnit:
         for testsuite_element in tree.iter("testsuite"):
             testcase_keys = deepcopy(self._summary_keys)
             for key in testcase_keys:
-                testcase_keys[key] = get_attribute()
+                testcase_keys[key] = get_attribute() if key != "ignored_on_failure" else testcase_keys[key]
                 if key == "failures" and testcase_keys[key] > 0 and self.ignore_set:
                     testcase_keys[key] = filter_out_ignored_failed_test()
 

--- a/report_templates/report.html
+++ b/report_templates/report.html
@@ -154,6 +154,7 @@
                         <th>Failures</th>
                         <th>Errors</th>
                         <th>Skipped</th>
+                        <th>Ignored On Failure</th>
                     </tr>
                     <tr>
                         <td>{{ test }}</td>
@@ -171,6 +172,7 @@
                             <td class='result_table_error'>{{ summary.testsuite_summary.errors }}</td>
                         {% endif %}
                         <td>{{ summary.testsuite_summary.skipped }}</td>
+                        <td>{{ summary.testsuite_summary.ignored_on_failure }}</td>
                     </tr>
                 </table>
             {% endif %}


### PR DESCRIPTION
1. Report `ignored_on_failure` tests in the email
2. Fix issue when `ignored_on_failure` number is reset to zero in summary

Testing:

- [x] [rust-driver-matrix](https://argus.scylladb.com/test/bd78a051-9bdd-4f70-b554-b881cd3cf1b7/runs?additionalRuns[]=db08e185-ba1d-4efa-a5f5-ffd4d9a6a973)

![Screenshot from 2024-05-23 14-46-38](https://github.com/scylladb/scylla-rust-driver-matrix/assets/34435448/ff113607-da79-475a-aea0-371da4045919)

