### PR TITLE
improvement(ignore): update ignore.yamls

### DIFF
--- a/versions/scylla/v0.12.0/ignore.yaml
+++ b/versions/scylla/v0.12.0/ignore.yaml
@@ -1,6 +1,5 @@
 tests:
   ignore:
-    - transport::cql_types_test::test_naive_date
     # https://github.com/scylladb/scylla-rust-driver/issues/1018
     - transport::caching_session::tests::test_partitioner_name_caching
     - transport::session_test::test_table_partitioner_in_metadata

--- a/versions/scylla/v0.13.0/ignore.yaml
+++ b/versions/scylla/v0.13.0/ignore.yaml
@@ -1,0 +1,6 @@
+tests:
+  ignore:
+    # https://github.com/scylladb/scylla-rust-driver/issues/1018
+    - transport::session_test::test_batch_lwts
+    - lwt_optimisation::if_lwt_optimisation_mark_offered_then_negotiatied_and_lwt_routed_optimally
+    - tablets::test_lwt_optimization_works_with_tablets (cargo test)


### PR DESCRIPTION
According to https://github.com/scylladb/scylla-rust-driver/issues/1018 there are few tests that expected to fail in the version v0.11.1 and v0.12.0. Update existing ignore.yaml for 'v0.11.1' and create new for 'v0.12.0'

### Testing
- [x] [rust-driver-matrix-test](https://argus.scylladb.com/test/9e1dd913-1c47-4ee1-81c9-ec5d063891bd/runs?additionalRuns[]=39f48d9a-82f1-4dd0-b068-7f5c26bd89cb)