### PR TITLE
Add `ip` command to docker image

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -212,6 +212,7 @@ RUN set -eux; \
 RUN apt-get -y update
 RUN apt-get install -y software-properties-common
 RUN apt-get -y install openjdk-11-jre-headless
+RUN apt-get -y install iproute2
 RUN rm -rf /var/lib/apt/lists/*
 
 ADD requirements.txt requirements.txt

--- a/scripts/image
+++ b/scripts/image
@@ -1,1 +1,1 @@
-scylladb/scylla-rust-driver-matrix:nightly-rust.2025-06-02-python3.11-20250604
+scylladb/scylla-rust-driver-matrix:nightly-rust.2025-06-02-python3.11-20250604-2


### PR DESCRIPTION
A few months ago an integration test was added to Rust Driver that calls `ip route get`.
Matrix was failing for other reasons, so it went unnoticed, but now that I updated the toolchain this started to fail.

As a bonus I removed some dead code.