### PR TITLE
Ignore test_default_policy_is_tablet_aware test

### DIFF
--- a/versions/scylla/v1.1.0/ignore.yaml
+++ b/versions/scylla/v1.1.0/ignore.yaml
@@ -2,3 +2,4 @@ tests:
     ignore:
         # https://github.com/scylladb/scylla-rust-driver/issues/1369
         - "scylla/src/client/session_builder.rs - client::session_builder::GenericSessionBuilder<DefaultMode>::tls_context (line 334)"
+        - "load_balancing::tablets::test_default_policy_is_tablet_aware"

--- a/versions/scylla/v1.2.0/ignore.yaml
+++ b/versions/scylla/v1.2.0/ignore.yaml
@@ -2,3 +2,5 @@ tests:
     ignore:
         # https://github.com/scylladb/scylla-rust-driver/issues/1369
         - "scylla/src/client/session_builder.rs - client::session_builder::GenericSessionBuilder<DefaultMode>::tls_context (line 333)"
+        # https://github.com/scylladb/scylla-rust-driver-matrix/issues/26
+        - "load_balancing::tablets::test_default_policy_is_tablet_aware"


### PR DESCRIPTION
This test is often failing. The issue is described in https://github.com/scylladb/scylla-rust-driver-matrix/issues/26
Even after we fix the test in the driver, it will keep failing for older versions, so it needs to be ignored.