### PR TITLE
v1.1.0/ignore.yaml: Fixed invalid test name

### DIFF
--- a/versions/scylla/v1.1.0/ignore.yaml
+++ b/versions/scylla/v1.1.0/ignore.yaml
@@ -2,4 +2,5 @@ tests:
     ignore:
         # https://github.com/scylladb/scylla-rust-driver/issues/1369
         - "scylla/src/client/session_builder.rs - client::session_builder::GenericSessionBuilder<DefaultMode>::tls_context (line 334)"
-        - "load_balancing::tablets::test_default_policy_is_tablet_aware"
+        # https://github.com/scylladb/scylla-rust-driver-matrix/issues/26
+        - "tablets::test_default_policy_is_tablet_aware"


### PR DESCRIPTION
Old name was copied from 1.2.0, but between 1.1.0 and 1.2.0 we did refactor integration test structure in Rust Driver. This ignore was also missing a link to the issue.